### PR TITLE
Update RESTSdmxBeanRetrievalManager.java

### DIFF
--- a/SdmxStructureRetrieval/src/main/java/org/sdmxsource/sdmx/structureretrieval/manager/RESTSdmxBeanRetrievalManager.java
+++ b/SdmxStructureRetrieval/src/main/java/org/sdmxsource/sdmx/structureretrieval/manager/RESTSdmxBeanRetrievalManager.java
@@ -93,7 +93,9 @@ public class RESTSdmxBeanRetrievalManager extends BaseSdmxBeanRetrievalManager {
             throw new SdmxException(e, "Could not open a conneciton to URL: " + restQuery);
         }
         ReadableDataLocation rdl = rdlFactory.getReadableDataLocation(restURL);
-        return spm.parseStructures(rdl).getStructureBeans(false);
+		SdmxBeans result = spm.parseStructures(rdl).getStructureBeans(false);
+		rdl.close();
+		return result;
     }
 
     @Override


### PR DESCRIPTION
ReadableDataLocation object shall be closed. Otherwise temporary files are never closed (see SdmxSourceReadableDataLocationFactory class).
I do not remember exactly how I found out that problem because I modified this code in my project 3 years ago. But I think it created slowdown.