### PR TITLE
remove optional type attribute for StreamCompactDataWriterEngine

### DIFF
--- a/SdmxDataParser/src/main/java/org/sdmxsource/sdmx/dataparser/engine/writer/streaming/StreamCompactDataWriterEngine.java
+++ b/SdmxDataParser/src/main/java/org/sdmxsource/sdmx/dataparser/engine/writer/streaming/StreamCompactDataWriterEngine.java
@@ -128,7 +128,6 @@ public class StreamCompactDataWriterEngine extends StreamDataWriterEngineBase {
 
             if (isTwoPointOne()) {
                 writer.writeStartElement("Group");      //WRITE THE START GROUP
-                writer.writeAttribute(XSI_NS, "type", COMPACT_NS.namespacePrefix + ":" + groupId);
                 writeAnnotations(writer, annotations);
             } else {
                 groupAnnotations = annotations;


### PR DESCRIPTION
as per spec, for structure specific format this attribute is optional, thus, may be removed

(cherry picked from commit 191651cbe4aa0dd25aa6149a6bbb24ab577a1d5a)